### PR TITLE
Refactor from global variable to RenderSettings

### DIFF
--- a/render_music/__init__.py
+++ b/render_music/__init__.py
@@ -94,6 +94,7 @@ def register():
     bpy.utils.register_class(RenderMusicProperties)
     bpy.types.RENDER_PT_render.append(render_panel)
 
+    bpy.types.RenderSettings.music_handle = None
     bpy.app.handlers.render_pre.append(render_music.play_music)
     bpy.app.handlers.render_cancel.append(render_music.kill_music)
     bpy.app.handlers.render_complete.append(render_music.end_music)

--- a/render_music/render_music.py
+++ b/render_music/render_music.py
@@ -21,11 +21,9 @@
 import bpy, aud
 from bpy.app.handlers import persistent
 
-handle = "" #XXX UGLY
-
 @persistent
 def play_music(scene):
-    global handle
+    handle = bpy.types.RenderSettings.music_handle
     addon_prefs = bpy.context.user_preferences.addons[__package__].preferences
 
     if addon_prefs.use_play:
@@ -33,12 +31,12 @@ def play_music(scene):
             print("Playing elevator music...")
             device = aud.device()
             factory = aud.Factory(addon_prefs.playfile)
-            handle = device.play(factory)
+            bpy.types.RenderSettings.music_handle = device.play(factory)
             handle.loop_count = -1
 
 @persistent
 def kill_music(scene):
-    global handle
+    handle = bpy.types.RenderSettings.music_handle
 
     if hasattr(handle, "status") and handle.status == True:
         print("Killing elevator music...")
@@ -46,6 +44,7 @@ def kill_music(scene):
 
 @persistent
 def end_music(scene):
+    handle = bpy.types.RenderSettings.music_handle
     addon_prefs = bpy.context.user_preferences.addons[__package__].preferences
     
     kill_music(scene)
@@ -53,4 +52,4 @@ def end_music(scene):
     if addon_prefs.use_end:
         device = aud.device()
         factory = aud.Factory(addon_prefs.endfile)
-        handle = device.play(factory)
+        bpy.types.RenderSettings.music_handle = device.play(factory)


### PR DESCRIPTION
This uses `bpy.types.RenderSettings to store data`, eliminating the #XXX UGLY
marker previously required. This is the recommended method according to [this BlenderArtists thread](http://www.blender.org/forum/viewtopic.php?t=27291&sid=20cbbe81c75ff34fae56d48d8c0670ca).

I have tested this on my local machine and it works as intended.
